### PR TITLE
Fix pypykatz link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ C:\minidump.exe lsass.dmp
 
 Minidump is based on the following projects and the work by the creators
 
-* [pypykatz](https://github.com/skelsec/pypykat) by [skelsec](https://twitter.com/SkelSec)
+* [pypykatz](https://github.com/skelsec/pypykatz) by [skelsec](https://twitter.com/SkelSec)
 * [mimikatz](https://github.com/gentilkiwi/mimikatz/) by [gentilkiwi](https://twitter.com/gentilkiwi)
 * [sharpkatz](https://github.com/b4rtik/SharpKatz) by [b4rtik](https://twitter.com/b4rtik)


### PR DESCRIPTION
Fix the link to pypykatz in the readme